### PR TITLE
Make a distinction between Arduino Micro and Sparkfun Pro Micro

### DIFF
--- a/arduino-cmsis-dap.ino
+++ b/arduino-cmsis-dap.ino
@@ -25,11 +25,17 @@
  * we can't override this from within the sketch -- you'll have to edit
  * files in your Arduino installation to change it.
  *
- * Pro Micro:
+ * Arduino Micro:
  *   Inside your Arduino installation, edit hardware/arduino/avr/boards.txt
  *   and add CMSIS-DAP to micro.build.usb_product:
  *
  *   micro.build.usb_product="Arduino Micro CMSIS-DAP"
+ *
+ * Sparkfun Pro Micro:
+ *   Inside your Arduino installation, edit ~/.arduino15/packages/SparkFun/hardware/avr/1.1.12/boards.txt
+ *   and add CMSIS-DAP to micro.build.usb_product:
+ *
+ *   promicro.build.usb_product="SparkFun Pro Micro CMSIS-DAP"
  *
  * Teensy 3.2:
  *   Inside your Arduino installation, edit hardware/teensy/avr/cores/teensy3/usb_desc.h

--- a/board.cpp
+++ b/board.cpp
@@ -94,7 +94,7 @@
 #define BOARD_ID        "1062"
 #define BOARD_SECRET    "xxxxxxxx"
 
-#elif defined(ARDUINO_AVR_MICRO) || defined(TEENSYDUINO)
+#elif defined(ARDUINO_AVR_MICRO) || defined(TEENSYDUINO) || defined(ARDUINO_AVR_PROMICRO)
 #define BOARD_ID        {1, 1, 1, 1}
 #define BOARD_SECRET    {1, 1, 1, 1, 1, 1, 1, 1, 1}
 


### PR DESCRIPTION
The sketch compiles for my Sparkfun Pro Micro (the one you linked in the readme) only when board.cpp has the correct board define.

Also added instructions on where to edit the board.txt for the actual Pro Micro